### PR TITLE
fix assignment group target for only one account

### DIFF
--- a/src/templates/100-aws-sso/aws-sso.yml
+++ b/src/templates/100-aws-sso/aws-sso.yml
@@ -66,7 +66,8 @@ Resources:
       PrincipalType: GROUP
       Targets:
         - TargetType: AWS_ACCOUNT
-          TargetIds: Fn::EnumTargetAccounts TargetBinding ${account}
+          TargetIds:
+            - Fn::EnumTargetAccounts TargetBinding ${account}
 
 Outputs:
   PermissionSetArn:


### PR DESCRIPTION
When having only one account, `AssignmentGroup` failed expecting `JSONArray` instead of `String`. This fix allows `TargetIds` to support from one to many accounts