### PR TITLE
fix: account creation notification and event rules

### DIFF
--- a/src/templates/050-account-creation/_tasks.yml
+++ b/src/templates/050-account-creation/_tasks.yml
@@ -6,7 +6,7 @@ AccountCreationEvent:
   Template: ./event.yml
   StackName: !Sub '${resourcePrefix}-account-creation'
   DefaultOrganizationBinding:
-    IncludeMasterAccount: true
+    Account: !Ref OrgBuildAccount
     Region: us-east-1
   Parameters:
     organizationPrincipalId: !Ref organizationPrincipalId


### PR DESCRIPTION
Account creation notification and event rules part in 050-account-creation need to be in the OrgBuildAccount