### PR TITLE
fix: password-policy stack needs to run in us-east-1

### DIFF
--- a/src/templates/005-types/_tasks.yml
+++ b/src/templates/005-types/_tasks.yml
@@ -72,7 +72,7 @@ PasswordPolicyRp:
   OrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
-    Region: !Ref primaryRegion
+    Region: us-east-1 # Only compatible to us-east-1 region
 
 ServiceQuotasS3Rp:
   Type: register-type

--- a/src/templates/020-secure-defaults/_tasks.yml
+++ b/src/templates/020-secure-defaults/_tasks.yml
@@ -11,7 +11,7 @@ PasswordPolicy:
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
     Account: '*'
-    Region: !Ref primaryRegion
+    Region: us-east-1 # Only compatible to us-east-1 region
 
 SecureDefaults:
   Type: update-stacks


### PR DESCRIPTION
Password-policy stack needs to run in us-east-1.  The corresponding register-type PasswordPolicy also needs to exist in us-east-1