### PR TITLE
Allow setting a custom policy for SSO roles

### DIFF
--- a/src/templates/100-aws-sso/_tasks.yml
+++ b/src/templates/100-aws-sso/_tasks.yml
@@ -171,4 +171,4 @@ SsoViewerSupporter:
     instanceArn: !Ref instanceArn
     principalId: !Ref supporterGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
-    managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]
+    managedPolicies: [ 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess' ]

--- a/src/templates/100-aws-sso/_tasks.yml
+++ b/src/templates/100-aws-sso/_tasks.yml
@@ -68,6 +68,7 @@ SsoAdministratorSupporter:
     instanceArn: !Ref instanceArn
     principalId: !Ref supporterGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-admin-permission-set-arn' ]
+    managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]
 
 SsoWriter:
   Type: update-stacks
@@ -170,3 +171,4 @@ SsoViewerSupporter:
     instanceArn: !Ref instanceArn
     principalId: !Ref supporterGroup
     permissionSetArn: !CopyValue [ !Sub '${resourcePrefix}-${appName}-viewer-permission-set-arn' ]
+    managedPolicies: [ 'arn:aws:iam::aws:policy/AdministratorAccess' ]

--- a/src/templates/100-aws-sso/aws-sso.yml
+++ b/src/templates/100-aws-sso/aws-sso.yml
@@ -16,9 +16,17 @@ Parameters:
     Type: String
     Default: AdministratorAccess
 
+  # Must provide either a list of managedPolicies or an inlinePolicy.
+  # Can also provide both a list of managedPolicies and an inlinePolicy.
   managedPolicies:
     Type: CommaDelimitedList
-    Default: arn:aws:iam::aws:policy/AdministratorAccess
+    Default: ''
+    Description: 'A list of AWS managed policy ARNs for a SSO permission set'
+
+  inlinePolicy:
+    Type: String
+    Default: ''
+    Description: 'An AWS policy document for a SSO permission set'
 
   sessionDuration:
     Type: String
@@ -32,6 +40,10 @@ Conditions:
 
   includePermissionSet: !Equals [ '', !Ref permissionSetArn ]
   includeMaster: !Not [ !Equals [ '', !Ref masterAccountId ] ]
+  includeInlinePolicy: !Not [ !Equals [ '', !Ref inlinePolicy ] ]
+  includeManagedPolicies: !Not
+    - !Equals
+      - !Join ['', !Ref managedPolicies]
 
 Resources:
 
@@ -42,8 +54,9 @@ Resources:
       Name: !Ref permissionSetName
       Description: !Sub '${permissionSetName} access to AWS organization'
       InstanceArn: !Ref instanceArn
-      ManagedPolicies: !Ref managedPolicies
+      ManagedPolicies: !If [ includeManagedPolicies, !Ref managedPolicies, !Ref 'AWS::NoValue' ]
       SessionDuration: !Ref sessionDuration
+      InlinePolicy: !If [ includeInlinePolicy, !Ref inlinePolicy, !Ref 'AWS::NoValue' ]
 
   AssignmentMaster:
     Type: AWS::SSO::Assignment

--- a/src/templates/100-aws-sso/aws-sso.yml
+++ b/src/templates/100-aws-sso/aws-sso.yml
@@ -16,8 +16,6 @@ Parameters:
     Type: String
     Default: AdministratorAccess
 
-  # Must provide either a list of managedPolicies or an inlinePolicy.
-  # Can also provide both a list of managedPolicies and an inlinePolicy.
   managedPolicies:
     Type: CommaDelimitedList
     Default: ''


### PR DESCRIPTION
AWS SSO parmeter sets do not support customer managed policies[1]
The only way to set custom policies for an SSO role is to configure
an inline policy.  This change allows passing in an inline policy to the
AWS SSO template.  The inline policy is an AWS policy document in json.

example:

```
    inlinePolicy: >-
      {
        "Version": "2012-10-17",
        "Statement": [
          {
            "Effect": "Allow",
            "Action": [ "s3:ListAllMyBuckets" ],
            "Resource": "arn:aws:s3:::*"
          },
          {
            "Effect": "Allow",
            "Action": [ "s3:ListBucket", "s3:GetBucketLocation" ],
            "Resource": [
              "arn:aws:s3:::MY-BUCKET"
            ]
          }
        ]
      }
```

[1] https://forums.aws.amazon.com/thread.jspa?threadID=282793