### PR TITLE
fix: update AccessAnalyzer example

### DIFF
--- a/src/templates/020-secure-defaults/_tasks.yml
+++ b/src/templates/020-secure-defaults/_tasks.yml
@@ -52,15 +52,13 @@ OrganizationPolicies:
     IncludeMasterAccount: true
     Region: us-east-1
 
-# TODO: should work after this issue is fixed:
-# https://github.com/org-formation/aws-resource-providers/issues/74
-# AccessAnalyzer:
-#   Type: update-stacks
-#   Template: ./access-analyzer.yml
-#   StackName: !Sub '${resourcePrefix}-access-analyzer'
-#   MaxConcurrentStacks: 10
-#   Parameters:
-#     targetId: !Ref SecurityAccount
-#   DefaultOrganizationBinding:
-#     IncludeMasterAccount: true
-#     Region: us-east-1
+AccessAnalyzer:
+  Type: update-stacks
+  Template: ./access-analyzer.yml
+  StackName: !Sub '${resourcePrefix}-access-analyzer'
+  MaxConcurrentStacks: 10
+  Parameters:
+    targetId: !Ref SecurityAccount
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Region: us-east-1

--- a/src/templates/020-secure-defaults/access-analyzer.yml
+++ b/src/templates/020-secure-defaults/access-analyzer.yml
@@ -11,6 +11,7 @@ Resources:
     Type: Community::Organizations::EnableAWSServiceAccess
     Properties:
       ServicePrincipal: access-analyzer.amazonaws.com
+      ResourceId: enable-access-analyzer
 
   AccessAnalyzerDelegatedAdmin:
     Type: Community::Organizations::DelegatedAdmin


### PR DESCRIPTION
Fix the AccessAnalyzer task example by adding the missing required `ResourceId` property to the `AccessAnalyzerServiceAccess` resource of type `Community::Organizations::EnableAWSServiceAccess` in the `src/templates/020-secure-defaults/access-analyzer.yml` file and uncommenting the `AccessAnalyzer` task in the`src/templates/020-secure-defaults/_tasks.yml` file.