### PR TITLE
Update EbsEncryptionDefaultsRp and AccountPublicAccessBlockRp versions in the reference

### DIFF
--- a/src/templates/005-types/_tasks.yml
+++ b/src/templates/005-types/_tasks.yml
@@ -20,7 +20,7 @@ NoDefaultVpcRp:
 EbsEncryptionDefaultsRp:
   Type: register-type
   ResourceType: "Community::Organizations::EbsEncryptionDefaults"
-  SchemaHandlerPackage: !Sub "s3://${catalogBucket}/community-ec2-ebsencryptiondefaults-0.2.0.zip"
+  SchemaHandlerPackage: !Sub "s3://${catalogBucket}/community-ec2-ebsencryptiondefaults-0.2.1.zip"
   MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true
@@ -39,7 +39,7 @@ OrganizationsPolicyRp:
 AccountPublicAccessBlockRp:
   Type: register-type
   ResourceType: "Community::S3::PublicAccessBlock"
-  SchemaHandlerPackage: !Sub "s3://${catalogBucket}/community-s3-publicaccessblock-0.2.0.zip"
+  SchemaHandlerPackage: !Sub "s3://${catalogBucket}/community-s3-publicaccessblock-0.2.2.zip"
   MaxConcurrentTasks: 100
   OrganizationBinding:
     IncludeMasterAccount: true


### PR DESCRIPTION
I recently applied the reference template to an organisation and found that these custom types were not permitted to perform their IAM Actions. I tracked this down to the [self protect SCP](https://github.com/org-formation/org-formation-reference/blob/master/src/templates/010-scps/self-protect.yml) which [limits access](https://github.com/org-formation/org-formation-reference/blob/c865611bc55ff0d727fefbb92e38faa56a61afa3/src/templates/010-scps/self-protect.yml#L36-L46) to the `ec2:DisableEbsEncryptionByDefault` and `s3:PutAccountPublicAccessBlock` IAM Actions. These updated versions place their IAM Role in the `/community-types/` Path which the SCP self-protect policy permits to perform the IAM Actions they execute.