### PR TITLE
fix: update 080-aws-config-inventory

### DIFF
--- a/src/templates/080-aws-config-inventory/config.yml
+++ b/src/templates/080-aws-config-inventory/config.yml
@@ -79,7 +79,7 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       ManagedPolicyArns:
-      - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
+      - 'arn:aws:iam::aws:policy/service-role/AWS_ConfigRole'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
Change deprecated AWSConfigRole to use the managed service role AWS_ConfigRole. 

https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/