### PR TITLE
Fix variable name for secure defaults

### DIFF
--- a/src/templates/020-secure-defaults/_tasks.yml
+++ b/src/templates/020-secure-defaults/_tasks.yml
@@ -8,7 +8,7 @@ RegisterTypes:
   Path: register-type-tasks.yml
   MaxConcurrentTasks: 10
   Parameters:
-    region: !Ref primaryRegion
+    primaryRegion: !Ref primaryRegion
     allRegions: !Ref allRegions
 
 PasswordPolicy:


### PR DESCRIPTION
In that file, the parameter is named `primaryRegion`, but the type in the caller (Secure defaults) is `primary`. I've gone with the former as the comment says `primaryRegion`.

https://github.com/org-formation/org-formation-reference/blob/1722159cff25177919f66a3398d218885a427fb0/src/templates/020-secure-defaults/register-type-tasks.yml#L1-L7

The `primaryRegion` parameter isn't used for anything, in that file, so this hasn't _yet_ caused an issue, for people who haven't added their own entries to `register-type-tasks.yml`.